### PR TITLE
Fix: Update better-auth import path to integrations/nextjs

### DIFF
--- a/app/api/auth/[...better-auth]/route.ts
+++ b/app/api/auth/[...better-auth]/route.ts
@@ -1,6 +1,4 @@
 import { auth } from '@/lib/auth';
-import { toNextJsHandler } from 'better-auth/nextjs';
-
+import { toNextJsHandler } from 'better-auth/integrations/nextjs';
 const { GET, POST } = toNextJsHandler(auth);
-
 export { GET, POST };


### PR DESCRIPTION
Updated the import statement from 'better-auth/nextjs' to 'better-auth/integrations/nextjs' to align with the correct better-auth package structure.